### PR TITLE
Export using module.exports approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel-runtime": "6.18.0",
-    "babel-plugin-transform-runtime": "6.23.0",
-    "babel-preset-es2015": "6.24.1",
-    "babelify": "7.3.0",
     "md5": "^2.2.1",
     "tangram-cartocss": "cartodb/tangram-carto#master",
     "yamljs": "^0.2.8"
   },
   "devDependencies": {
+    "babel-runtime": "6.18.0",
+    "babel-plugin-transform-runtime": "6.23.0",
+    "babel-preset-es2015": "6.24.1",
+    "babelify": "7.3.0",
     "brfs": "^1.4.3",
     "browserify": "14.3.0",
     "browserify-derequire": "0.9.4",
@@ -58,8 +58,5 @@
     "jshint": "jshint/jshint#3a8efa979dbb157bfb5c10b5826603a55a33b9ad",
     "tangram": "tangrams/tangram#master",
     "uglify-js": "3.0.11"
-  },
-  "browserify": {
-    "transform": [["babelify", { "presets": ["es2015"] }]]
   }
 }

--- a/src/tangram.js
+++ b/src/tangram.js
@@ -1,25 +1,8 @@
-import CCSS from 'tangram-cartocss';
-import yaml from './yaml';
-import md5 from 'md5';
+const CCSS = require('tangram-cartocss');
+const yaml = require('./yaml');
+const md5 = require('md5');
 
-var SOURCES = {
-    mapnik: {
-        type: 'MVT'
-    }
-};
-
-var generateSources = function generateSources(url, subdomains) {
-  // TODO: make this dynamic if it is neccessary
-  var source = SOURCES.mapnik;
-
-  return {
-    type: source.type,
-    url: url,
-    url_subdomains: subdomains
-  };
-};
-
-var TC = function (map, cb) {
+function TC(map, cb) {
   this.layer = Tangram.leafletLayer({
     scene: yaml.getBaseFile()
   }).addTo(map);
@@ -32,8 +15,26 @@ var TC = function (map, cb) {
       cb();
     }
   });
+}
 
+module.exports = TC;
+
+var SOURCES = {
+    mapnik: {
+        type: 'MVT'
+    }
 };
+
+function generateSources(url, subdomains) {
+  // TODO: make this dynamic if it is neccessary
+  var source = SOURCES.mapnik;
+
+  return {
+    type: source.type,
+    url: url,
+    url_subdomains: subdomains
+  };
+}
 
 TC.prototype = {
   onLoaded: function (cb) {
@@ -89,5 +90,3 @@ TC.prototype = {
     this.scene.setDataSource('CartoDB', generateSources(url, subdomains));
   }
 };
-
-export default TC;

--- a/src/yaml.js
+++ b/src/yaml.js
@@ -1,4 +1,4 @@
-import yamljs from 'yamljs';
+const yamljs = require('yamljs');
 
 const getBaseProperties = function getBaseProperties() {
   return {
@@ -36,7 +36,4 @@ const getBaseFile = function () {
   return URL.createObjectURL( new Blob( [ generateYAML() ] ) );
 };
 
-var yaml;
-export default yaml = {
-  getBaseFile
-};
+module.exports.getBaseFile = getBaseFile;


### PR DESCRIPTION
This simplifies integration with existing libraries, and avoids requiring babelify-* in them.