### PR TITLE
fix tangram-carto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "md5": "^2.2.1",
-    "tangram-cartocss": "cartodb/tangram-carto#master",
+    "tangram-cartocss": "cartodb/tangram-carto#eaf28709e83d4980aedd0c5434e5d5693558cf95",
     "yamljs": "^0.2.8"
   },
   "devDependencies": {


### PR DESCRIPTION
fix tangram-carto to the point of the history before starting to mess with ES6 in dependent projects (i.e. deep-insights.js)

we should really start publishing version releases so we don't depend on just the master version of tangram-cartocss.

/cc @rochoa @IagoLast 