### PR TITLE
Tangramcss rewrite

### DIFF
--- a/demos/lib/carto-helpers.js
+++ b/demos/lib/carto-helpers.js
@@ -53,5 +53,5 @@ Carto.generateSource = function (datasource) {
   return datasource.maps_api_template.replace( '{user}', datasource.user_name ) +
                 '/api/v1/map/named/' +
                 id.replace(/-/g, '_') +
-                '/mapnik/{z}/{x}/{y}.mvt';
+                '/mapnik/{z}/{x}/{y}.mvt?config=' + encodeURIComponent(JSON.stringify({buffersize: { mvt: 0 }}));
 }

--- a/demos/main.js
+++ b/demos/main.js
@@ -2,7 +2,7 @@ import Carto from './lib/carto-helpers';
 import Utils from './lib/utils';
 import TangramCarto from '../src/tangram';
 
-const MAP_URI = 'https://iago-carto.carto.com/builder/78ef5f8a-27e6-47c9-9c8b-51ef539a529e/embed';
+const MAP_URI = 'https://dmanzanares.carto.com/builder/68e825ce-5d96-42db-902f-e590fa69911a/embed';
 const ZOOM = 2;
 const CENTER = [42.34, -71.0];
 const BASE_MAP = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "tangram-cartocss": "cartodb/tangram-cartocss#cartocss-support-api",
+    "tangram-cartocss": "0.8.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "tangram-cartocss": "github:CartoDB/tangram-cartocss#rewrite",
+    "tangram-cartocss": "0.7.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "md5": "^2.2.1",
     "tangram-cartocss": "^0.6.0",
-    "yamljs": "^3.0.0"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "babel-plugin-transform-runtime": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "md5": "^2.2.1",
     "tangram-cartocss": "^0.6.0",
-    "yamljs": "^0.2.8"
+    "yamljs": "^3.0.0"
   },
   "devDependencies": {
     "babel-plugin-transform-runtime": "6.23.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "md5": "^2.2.1",
-    "tangram-cartocss": "^0.6.0",
+    "tangram-cartocss": "github:CartoDB/tangram-cartocss#rewrite",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "tangram-cartocss": "0.7.0",
+    "tangram-cartocss": "cartodb/tangram-cartocss#cartocss-support-api",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "md5": "^2.2.1",
     "tangram-cartocss": "github:CartoDB/tangram-cartocss#rewrite",
     "yamljs": "^0.3.0"
   },

--- a/src/tangram.js
+++ b/src/tangram.js
@@ -92,7 +92,7 @@ TC.prototype = {
           source: 'CartoDB'
         },
         draw: yaml.draw,
-        visible: l.visible
+        visible: layer.visible
       };
 
       const layerName = `layer_${i}`;

--- a/src/tangram.js
+++ b/src/tangram.js
@@ -81,6 +81,8 @@ TC.prototype = {
     }, 0);
   },
 
+
+  //We receive a Builder's layer, that is composed by multiple sub-layers (draw-groups)
   addLayer: function (layer) {
     let layers = CartoCSSRenderer.render(layer.meta.cartocss).getLayers();
 

--- a/src/tangram.js
+++ b/src/tangram.js
@@ -84,10 +84,10 @@ TC.prototype = {
 
   //We receive a Builder's layer, that is composed by multiple sub-layers (draw-groups)
   addLayer: function (layer) {
-    let layers = CartoCSSRenderer.render(layer.meta.cartocss).getLayers();
+    let drawLayers = CartoCSSRenderer.render(layer.meta.cartocss).getLayers();
 
-    layers.forEach((l, i) => {
-      const yaml = CCSS.carto2Draw(l, i);
+    drawLayers.forEach((drawLayer, i) => {
+      const yaml = CCSS.carto2Draw(drawLayer, i);
       let ly = {
         data: {
           layer: layer.id,


### PR DESCRIPTION
This PR is meant to  use the new tangram-cartocss rewrite.

It improves the demo by setting the buffersize to 0.

It updates the YamlJS version to fix https://github.com/CartoDB/tangram.cartodb/issues/19

Right now, it is a basic fix to make it work, but we may want to merge this repo with tangram-css in the future.

The important changes are on https://github.com/CartoDB/tangram-cartocss