### PR TITLE
Fix for multiple layers

### DIFF
--- a/demos/main.js
+++ b/demos/main.js
@@ -2,7 +2,7 @@ import Carto from './lib/carto-helpers';
 import Utils from './lib/utils';
 import TangramCarto from '../src/tangram';
 
-const MAP_URI = 'https://dmanzanares.carto.com/builder/68e825ce-5d96-42db-902f-e590fa69911a/embed';
+const MAP_URI = 'https://dmanzanares.carto.com/builder/12157228-e488-4442-a3da-88ae27e0422b/embed';
 const ZOOM = 2;
 const CENTER = [42.34, -71.0];
 const BASE_MAP = 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';

--- a/src/tangram.js
+++ b/src/tangram.js
@@ -63,9 +63,9 @@ TC.prototype = {
 
 
   //We receive a Builder's layer, that is composed by multiple sub-layers (draw-groups)
-  addLayer: function (layer) {
+  addLayer: function (layer, superLayerOrder) {
+    CCSS.cartoCssToDrawGroups(layer.meta.cartocss, superLayerOrder).forEach((scene, i) => {
 
-    CCSS.cartoCssToDrawGroups(layer.meta.cartocss).forEach((scene, i) => {
       let ly = {
         data: {
           layer: layer.id,
@@ -76,7 +76,7 @@ TC.prototype = {
         visible: layer.visible
       };
 
-      const layerName = `layer_${i}`;
+      const layerName = `layer_${layer.id}_${i}`;
 
       this.scene.config.layers[layerName] = ly;
 
@@ -90,7 +90,6 @@ TC.prototype = {
         scene.textures
       );
     });
-
     this.scene.updateConfig({rebuild: true});
   },
 


### PR DESCRIPTION
Correctly call carto-css with the super layer order, and correctly set the layer name to avoid name clashing.